### PR TITLE
AUI-1823 Updating _concat so that we can construct uri correctly from th...

### DIFF
--- a/src/io/js/io-base.js
+++ b/src/io/js/io-base.js
@@ -395,8 +395,17 @@ IO.prototype = {
     * @return {String}
     */
     _concat: function(uri, data) {
-        uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
-        return uri;
+        if (uri.indexOf('#') === -1) {
+            uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
+            return uri;
+        } else {
+            var split = uri.split('&#');
+            var uri = split[0];
+            var anchor = split[1];
+
+            uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
+            return uri + '&#' + anchor;
+        }
     },
 
    /**


### PR DESCRIPTION
Hey @jonmak08 

Currently, YUI cannot handle uri containing anchor tag when sending ajax request.

For example the uri YUI receives is http://localhost:8080/web/guest/test?p_p_id=20&#p_20.

The anchor is #p_20.

In the method of _contact, it simply appends data after this uri. So the result is something like http://localhost:8080/web/guest/test?p_p_id=20&#p_20&parameters.

As all the characters after #  will be consider as an anchor, so the uri is constructed by mistake.

This causes the issue of [LPP-14470](https://issues.liferay.com/browse/LPP-14470).

The correct logic for constructing uri containing anchor tag is append it to the end of uri. So I re-write the method of _contract.

Please review this pr and let me know if you have any concerns.

Thanks
John.
