### PR TITLE
AUI-1823 Construting URI correctly with fragment.

### DIFF
--- a/src/io/js/io-base.js
+++ b/src/io/js/io-base.js
@@ -395,8 +395,17 @@ IO.prototype = {
     * @return {String}
     */
     _concat: function(uri, data) {
-        uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
-        return uri;
+        if (uri.indexOf('#') === -1) {
+            uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
+            return uri;
+        } else {
+            var split = uri.split('#');
+            var uri = split[0];
+            var fragment = split[1];
+            
+            uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
+            return uri + '#' + fragment;
+        }
     },
 
    /**


### PR DESCRIPTION
Hey @jonmak08 

The attached is a fix for [AUI-1823](http://issues.liferay.com/browse/AUI-1823).

If the URI containing fragment (fragment begins with '#'), data appending after uri will be considered as fragment. So the data will not be sent to be server as it is not a part of query, but fragment.

Here we want to appending data before '#', so that they can be parts of query in URI.  So I updated the _contract method.

For more details about fragment in URI, please refer to [this guide](https://tools.ietf.org/html/rfc3986).

Let me know if you have questions.

Thanks
John.
