### PR TITLE
[TECHNICAL SUPPORT] AUI-2108 YUI3's selector-css2.js throws a "Wrong number of arguments …

### DIFF
--- a/src/dom/js/selector-css2.js
+++ b/src/dom/js/selector-css2.js
@@ -74,7 +74,14 @@ var PARENT_NODE = 'parentNode',
                 className = token.className;
                 tagName = token.tagName || '*';
 
-                if (root.getElementsByTagName) { // non-IE lacks DOM api on doc frags
+                var getElementsByTagName = true;
+
+                try {
+                    getElementsByTagName = root.getElementsByTagName;
+                }
+                catch (e) {}
+
+                if (getElementsByTagName) { // non-IE lacks DOM api on doc frags
                     // try ID first, unless no root.all && root not in document
                     // (root.all works off document, but not getElementById)
                     if (id && (root.all || (root.nodeType === 9 || Y.DOM.inDoc(root)))) {


### PR DESCRIPTION
…or invalid property assignment" error in case of ie11

Hi Jon,

Sorry about I'm sending you directly this pull, originally I wanted to send it to Byran but I didn't find "patched-v3.18.1" branch in blzaugg/yui3 repo.

So, you can remember my previous yui3 request (AUI-2102). That fix, unfortunately, surfaced another ie11 issue.

Please see it on AUI-2108 ticket.

I'm not sure that my fix is the best for this issue but works (if I check it on Kaleo Designer portlet).
If you can give a better solution please do it.

Thanks a lot,
 Zsaga