### PR TITLE
LPS-72024 Datepicker box is responsive to month's name length

### DIFF
--- a/src/cssgrids/css/cssgrids-base.css
+++ b/src/cssgrids/css/cssgrids-base.css
@@ -33,17 +33,6 @@ https://github.com/yui/pure/blob/master/LICENSE.md
     * Helvetica, Arial, sans-serif: Common font stack on OS X and Windows.
     */
     font-family: FreeSans, Arimo, "Droid Sans", Helvetica, Arial, sans-serif;
-    /*
-    Use flexbox when possible to avoid `letter-spacing` side-effects.
-
-    NOTE: Firefox (as of 25) does not currently support flex-wrap, so the
-    `-moz-` prefix version is omitted.
-    */
-    display: -webkit-flex;
-    -webkit-flex-flow: row wrap;
-    /* IE10 uses display: flexbox */
-    display: -ms-flexbox;
-    -ms-flex-flow: row wrap;
 }
 
 /* Opera as of 12 on Windows needs word-spacing.


### PR DESCRIPTION
Hi Jonathan,

I forwarded to you this issue which represents a UX bug in the Liferay portal caused by the deleted portion of code from cssgrids-base.css file. The issue is that the datepicker popover is dynamic in a way that the user cannot switch months easily so he has to follow the arrows according to the popover width which is obviously annoying.

PS: This pull request aims to fix the 7.0 version of Liferay only since the previous versions are using another YUI version which doesn't contain this portion of code

that said, I would ask you to review this pull in order to fix this behavior.

thank you and best regards,
Omar
