### PR TITLE
WCM-1463 Fix the label missing issue when there are two labels have a same name

### DIFF
--- a/src/charts/js/CategoryAxis.js
+++ b/src/charts/js/CategoryAxis.js
@@ -86,24 +86,32 @@ Y.CategoryAxis = Y.Base.create("categoryAxis", Y.Axis, [Y.CategoryImpl], {
             data = this.get("data"),
             offset = edgeOffset;
         dataValues = dataValues || data;
-        for(i = 0; i < count; i = i + 1)
+        for(i = 0; i < data.length; i = i + 1)
         {
-            labelValue = dataValues[i];
-            labelIndex = Y.Array.indexOf(data, labelValue);
-            if(Y_Lang.isNumber(labelIndex) && labelIndex > -1)
-            {
-                point = {};
-                point[staticCoord] = constantVal;
-                point[dynamicCoord] = this._getCoordFromValue(
-                    min,
-                    max,
-                    layoutLength,
-                    labelIndex,
-                    offset
-                );
-                points.push(point);
-                values.push(labelValue);
-            }
+        	for (j = 0; j < dataValues.length; j = j + 1)
+        	{
+        		if (data[i] != dataValues[j])
+        		{
+        			continue;
+        		}
+        		labelValue = dataValues[i];
+        		labelIndex = i;
+        		if(Y_Lang.isNumber(labelIndex) && labelIndex > -1)
+        		{
+        			point = {};
+        			point[staticCoord] = constantVal;
+        			point[dynamicCoord] = this._getCoordFromValue(
+        				min,
+        				max,
+        				layoutLength,
+        				labelIndex,
+        				offset
+        			);
+        			points.push(point);
+        			values.push(labelValue);
+        		}
+			break;
+                }
         }
         return {
             points: points,


### PR DESCRIPTION
Hi @jonmak08 

I found this issue happens because when drawing a chart in YUI, It seems the developer didn't consider that there will be more than one labels have a same name. So, When positioning the labels, those labels with a same name will have a same location. And it seems like some labels are missing.

When I tried to fix this issue. I found this issue happens because the logic to position the label is searching index by the label's name. Like the follow code:
`labelIndex = Y.Array.indexOf(data, labelValue);`

I have some questions about the _getLabelData function:
1. `_getLabelData: function(constantVal, staticCoord, dynamicCoord, min, max, edgeOffset, layoutLength, count, dataValues)` What's the function of value "count"?
 Why not just use data.length and dataValues.length to get the size of array.
2. Why the value "dataValues" always be null?
3. Does data[] contains the whole labels?

On my fix, I assume that the "count" is useless, so I just use the data.length and dataValues.length.
I think the "dataValues" is a subset of "data" and "data" contains whole lables. But I am not sure.

Thanks for your help to review. If I understood wrong, kindly let me know please.

cc @yuhai
Best regards,
Seiphon