### PR TITLE
LPS-3189 Remove charset attribute from link elements according to W3C recommendations

### DIFF
--- a/src/get/js/get.js
+++ b/src/get/js/get.js
@@ -1058,6 +1058,7 @@ Transaction.prototype = {
                 nodeType = 'style';
             } else {
                 nodeType = 'link';
+                delete req.attributes['charset'];
             }
 
             node = req.node = this._createNode(nodeType, req.attributes,


### PR DESCRIPTION
Hi @jonmak08 ,

According to W3C [charset attribute is obsolete](https://www.w3.org/TR/html50/obsolete.html) in link element and we should avoid to use it.

> charset on link elements
> Use an HTTP Content-Type header on the linked resource instead.

Thanks.

Regards.

/cc @NemethNorbert