### PR TITLE
LPS-111463

### DIFF
--- a/src/widget-modality/js/Widget-Modality.js
+++ b/src/widget-modality/js/Widget-Modality.js
@@ -31,11 +31,10 @@ var WIDGET       = 'widget',
             el = doc.createElement('div');
             if (el && el.style) {
                 el.style.position = 'fixed';
-                el.style.top = '10px';
                 root = doc.body;
                 if (root && root.appendChild && root.removeChild) {
                     root.appendChild(el);
-                    isSupported = (el.offsetTop === 10);
+                    isSupported = (el.style.position === 'fixed');
                     root.removeChild(el);
                 }
             }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-111463

The error appears to occur because of how Chrome's rendering engine handles `position: fixed` at different zoom levels, so it's not reliable to use the existing `Widget-Modality.js` code in order to determine if `position: fixed` is supported.

To see why, navigate to any site using Chrome (doesn't need to use YUI), and run the following code (adapted from `supportsPosFixed` code in [widget-modality.js](https://github.com/liferay/yui3/blob/master/src/widget-modality/js/Widget-Modality.js#L22-L45)) in your browser console.

```javascript
var el = document.createElement('div');
el.style.position = 'fixed';
el.style.top = '10px';
document.body.appendChild(el);
console.log(el.offsetTop);
document.body.removeChild(el);
```

Then, re-run the code at each zoom level while zooming out. In Chrome, you should end up going through zoom values of 100%, 90%, 80%, 75%, 67%, 50%, 33%, 25%.

* **Expected behavior**: returns 10 at 25%, 33%, 50%, 67%, 75%, 80%, 90%, 100% zoom.
* **Actual behavior**: returns 10 at 50%, 80%, 90%, 100% zoom, returns 11 at 33%, 67%, 75% zoom, and returns 12 at 25% zoom.

From this, I concluded that the zoom level affects the final value of `offsetTop` when using `position: fixed` and the testing at different zoom levels shows that it can differ by a pixel or two.

Re-running the same code in Firefox at different zoom levels returns the expected result, so (for now, at least) Firefox's rendering engine does not appear to be affected by the same issues with `position: fixed`.